### PR TITLE
Fix(ArgoCD): Inexistant ingress Host route and fix password prompt

### DIFF
--- a/p3/confs/argocd-ingress.yaml
+++ b/p3/confs/argocd-ingress.yaml
@@ -14,7 +14,7 @@ spec:
         - name: argocd-server
           port: 80
     - kind: Rule
-      match: Host(`argocd.gitops.com`) && Header(`Content-Type`, `application/grpc`)
+      match: Host(`argocd.gitops.com`) && Headers(`Content-Type`, `application/grpc`)
       priority: 11
       services:
         - name: argocd-server

--- a/p3/scripts/install_softwares.sh
+++ b/p3/scripts/install_softwares.sh
@@ -87,8 +87,4 @@ function install_argocd()
     argocd login --core
 
     expose_port
-
-    # Get the initial password:
-    default_password="$(argocd admin initial-password -n argocd | head -1)"
-    export default_password
 }

--- a/p3/start.sh
+++ b/p3/start.sh
@@ -12,5 +12,8 @@ install_argocd
 
 create_app
 
+# Get the initial password:
+default_password="$(argocd admin initial-password -n argocd | head -1)"
+echo "=== ArgoCD credentials ==="
 echo "Username: admin"
 echo "Password: $default_password"


### PR DESCRIPTION
The used version of Traefik (2.11.18) was below that the documentation version used to configure Traefik on that part (3.x). So the function `Header` didn't exist on that time, and was called `Headers`. So I fixed the typo.

Also, the password was not prompting properly.